### PR TITLE
Fix #2 signal issue on py34

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,12 +44,17 @@ INSTALL_REQUIRES = reqs('requirements.txt')
 
 try:
     from pypandoc import convert
-    read_md = lambda f: convert(f, 'rst')
+
+    def read_md(f):
+        return convert(f, 'rst')
+
 except ImportError:
     print(
         "warning: pypandoc module not found, could not convert Markdown to RST"
     )
-    read_md = lambda f: open(f, 'r').read()
+
+    def read_md(f):
+        return open(f, 'r').read()  # noqa
 
 README = os.path.join(os.path.dirname(__file__), 'README.md')
 PACKAGES = find_packages('src')

--- a/src/ianitor/script.py
+++ b/src/ianitor/script.py
@@ -88,6 +88,10 @@ def main():
             signal.signal(signum, signal_handler)
         except RuntimeError:
             # signals that cannot be catched will raise RuntimeException
+            # (SIGKILL) ...
+            pass
+        except OSError:
+            # ... or OSError (SIGSTOP)
             pass
 
     while sleep(args.heartbeat) or service.is_up():
@@ -95,7 +99,8 @@ def main():
 
     logger.info("process quit with errorcode %s %s" % (
         service.process.poll(),
-        "(signal)" if service.process.poll() < 0 else ""
+        "(signal)" if service.process.poll() and service.process.poll() < 0
+        else ""
     ))
 
     service.deregister()

--- a/tests/test_args_parser.py
+++ b/tests/test_args_parser.py
@@ -40,15 +40,15 @@ def test_coordinates():
         args_parser.coordinates(":123")
 
 
-@patch('sys.argv', ["ianitor", "tailf", '--', 'tailf', 'something'])
+@patch('sys.argv', ["ianitor", "tailf", '--', 'tail', '-f', 'something'])
 def test_parse_args():
     args, invocation = args_parser.parse_args()
-    assert invocation == ['tailf', 'something']
+    assert invocation == ['tail', '-f', 'something']
 
 TEST_TTL = 100
 
 
-@patch('sys.argv', ["ianitor", "tailf", '--ttl', str(TEST_TTL), '--', 'tailf', 'something'])  # noqa
+@patch('sys.argv', ["ianitor", "tailf", '--ttl', str(TEST_TTL), '--', 'tail', '-f', 'something'])  # noqa
 def test_default_heartbeat():
     args, invocation = args_parser.parse_args()
     assert args.heartbeat == TEST_TTL / 10.

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2014 by Clearcode <http://clearcode.cc>
+# and associates (see AUTHORS.md).
+
+# This file is part of ianitor.
+
+# ianitor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# ianitor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public License
+# along with ianitor.  If not, see <http://www.gnu.org/licenses/>.
+from mock import patch
+
+
+from ianitor.service import Service
+import ianitor.script
+
+
+@patch('sys.argv', ["ianitor", "tail", "--", "tail", '-f', '/dev/null'])
+def test_script_main():
+    """Run ianitor.script.main and mock service is_up so it will quit
+    immediately"""
+
+    with patch.object(Service, "is_up", return_value=False) as is_up:
+        ianitor.script.main()
+        is_up.assert_any_call()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -26,7 +26,7 @@ from consul import Consul
 
 def get_tailf_service(session):
     return service.Service(
-        ["tailf", "/dev/null"],
+        ["tail", "-f", "/dev/null"],
         session=session,
         service_name="tailf",
         # small ttl for faster testing


### PR DESCRIPTION
Fix #2 issue on python3.4 caused by `OSError` exception not catched when trying to bind `SIGSTOP` signal