### PR TITLE
allow the setting of script or http checks

### DIFF
--- a/src/ianitor/script.py
+++ b/src/ianitor/script.py
@@ -74,7 +74,10 @@ def main():
         service_name=args.service_name,
         service_id=args.id,
         tags=args.tags,
-        port=args.port
+        port=args.port,
+        http=args.http,
+        script=args.script,
+        interval=args.interval,
     )
 
     service.start()

--- a/tests/test_args_parser.py
+++ b/tests/test_args_parser.py
@@ -58,3 +58,9 @@ TEST_TTL = 100
 def test_default_heartbeat():
     args, invocation = args_parser.parse_args()
     assert args.heartbeat == TEST_TTL / 10.
+
+
+@patch('sys.argv', ["ianitor", "tailf", '--ttl', str(TEST_TTL), '--', 'tail', '-f', 'something'])  # noqa
+def test_default_interval():
+    args, invocation = args_parser.parse_args()
+    assert args.interval == TEST_TTL / 10.


### PR DESCRIPTION
This allows the consul check to be a file or http check, rather than just allowing TTL checks. Only one check can be registered, so different checks have different priorities