### PR TITLE
Add --address option to set registered service address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-install: pip install tox --use-mirrors
+install: pip install tox
 env:
   matrix:
     # consul 0.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,32 @@ language: python
 
 install: pip install tox --use-mirrors
 env:
-  - TOX_ENV=py27
-  - TOX_ENV=py33
-  - TOX_ENV=pep8
-  - TOX_ENV=coverage
+  matrix:
+    # consul 0.4.1
+    - TOX_ENV=py27     CONSUL_VERSION=0.4.1
+    - TOX_ENV=py33     CONSUL_VERSION=0.4.1
+    - TOX_ENV=py34     CONSUL_VERSION=0.4.1
+    - TOX_ENV=py35     CONSUL_VERSION=0.4.1
+
+    # consul 0.5.2
+    - TOX_ENV=py27     CONSUL_VERSION=0.5.2
+    - TOX_ENV=py33     CONSUL_VERSION=0.5.2
+    - TOX_ENV=py34     CONSUL_VERSION=0.5.2
+    - TOX_ENV=py35     CONSUL_VERSION=0.5.2
+
+    # consul 0.6.4
+    - TOX_ENV=py27     CONSUL_VERSION=0.6.4
+    - TOX_ENV=py33     CONSUL_VERSION=0.6.4
+    - TOX_ENV=py34     CONSUL_VERSION=0.6.4
+    - TOX_ENV=py35     CONSUL_VERSION=0.6.4
+
+    # coverage and style checks
+    - TOX_ENV=pep8     CONSUL_VERSION=0.4.1
+    - TOX_ENV=coverage CONSUL_VERSION=0.4.1
 
 before_script:
-  - wget https://releases.hashicorp.com/consul/0.4.1/consul_0.4.1_linux_amd64.zip
-  - unzip consul_0.4.1_linux_amd64.zip
+  - wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip
+  - unzip consul_${CONSUL_VERSION}_linux_amd64.zip
   - start-stop-daemon --start --background --exec `pwd`/consul -- agent -server -data-dir /tmp/consul -bootstrap-expect=1
 
 script:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ your existing process/service supervision tool like
 [circus](http://circus.readthedocs.org/en/0.11.1/),
 [runit](http://smarden.org/runit/) etc.
 
+## Consul/Python versions compatibility
+
+**ianitor** is compatibile with Python 2.7, 3.3, 3.4, and 3.5 versions.
+It is also tested against each latest patch version of every major/minor consul
+release starting from 0.4.1 version.
+
+For details of our test matrix see `travis.yml` file.
 
 ## Installation and usage
 
@@ -26,25 +33,27 @@ And you're ready to go with:
     
 You can check if service is registered diggin' into consul DNS service:
 
-    $ dig @localhost -p 8600 appname.service.consul
-    ; <<>> DiG 9.9.3-P1 <<>> @localhost -p 8600 appname.service.consul
-    ; (1 server found)
-    ;; global options: +cmd
-    ;; Got answer:
-    ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 25966
-    ;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
-    ;; WARNING: recursion requested but not available
+```console
+$ dig @localhost -p 8600 appname.service.consul
+; <<>> DiG 9.9.3-P1 <<>> @localhost -p 8600 appname.service.consul
+; (1 server found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 25966
+;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+;; WARNING: recursion requested but not available
 
-    ;; QUESTION SECTION:
-    ;appname.service.consul.		IN	A
+;; QUESTION SECTION:
+;appname.service.consul.		IN	A
 
-    ;; ANSWER SECTION:
-    appname.service.consul.	0	IN	A	10.54.54.214
+;; ANSWER SECTION:
+appname.service.consul.	0	IN	A	10.54.54.214
 
-    ;; Query time: 44 msec
-    ;; SERVER: 127.0.0.1#8600(127.0.0.1)
-    ;; WHEN: Tue Oct 28 13:53:09 CET 2014
-    ;; MSG SIZE  rcvd: 78
+;; Query time: 44 msec
+;; SERVER: 127.0.0.1#8600(127.0.0.1)
+;; WHEN: Tue Oct 28 13:53:09 CET 2014
+;; MSG SIZE  rcvd: 78
+```
 
 Full usage:
 

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,12 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',  # noqa
     ],
 

--- a/src/ianitor/args_parser.py
+++ b/src/ianitor/args_parser.py
@@ -142,6 +142,11 @@ def get_parser():
     )
 
     parser.add_argument(
+        "--address",
+        help="set service address",
+    )
+
+    parser.add_argument(
         "--port",
         type=int,
         help="set service port",

--- a/src/ianitor/script.py
+++ b/src/ianitor/script.py
@@ -74,6 +74,7 @@ def main():
         service_name=args.service_name,
         service_id=args.id,
         tags=args.tags,
+        address=args.address,
         port=args.port
     )
 

--- a/src/ianitor/service.py
+++ b/src/ianitor/service.py
@@ -38,7 +38,7 @@ def ignore_connection_errors(action="unknown"):
 
 class Service(object):
     def __init__(self, command, session, ttl, service_name,
-                 service_id=None, tags=None, port=None):
+                 service_id=None, tags=None, address=None, port=None):
         self.command = command
         self.session = session
         self.process = None
@@ -46,6 +46,7 @@ class Service(object):
         self.ttl = ttl
         self.service_name = service_name
         self.tags = tags or []
+        self.address = address
         self.port = port
         self.service_id = service_id or service_name
 
@@ -94,6 +95,7 @@ class Service(object):
             self.session.agent.service.register(
                 name=self.service_name,
                 service_id=self.service_id,
+                address=self.address,
                 port=self.port,
                 tags=self.tags,
                 # format the ttl into XXXs format

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,pep8
+envlist = py27,py33,py34,py35,pep8
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ exclude=.git,.tox,dist,doc,*lib/python*,*egg,.idea,docs
 show-source = True
 
 [testenv:coverage]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps = pytest-cov
        coveralls
        {[testenv]deps}


### PR DESCRIPTION
When ianitor is used on a host that is not running a Consul agent, and you use --consul-agent to connect to a remote agent or peer to register the service, the address that was registered was the remote Consul agent or peer, not the host where the service resides. This option allows you to specify the IP address to use, as well as the port, in this circumstance.
