### PR TITLE
Bump python-consul version to 0.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,27 +3,27 @@ language: python
 install: pip install tox
 env:
   matrix:
-    # consul 0.4.1
-    - TOX_ENV=py27     CONSUL_VERSION=0.4.1
-    - TOX_ENV=py33     CONSUL_VERSION=0.4.1
-    - TOX_ENV=py34     CONSUL_VERSION=0.4.1
-    - TOX_ENV=py35     CONSUL_VERSION=0.4.1
+    # consul 0.7.5
+    - TOX_ENV=py27     CONSUL_VERSION=0.7.5
+    - TOX_ENV=py33     CONSUL_VERSION=0.7.5
+    - TOX_ENV=py34     CONSUL_VERSION=0.7.5
+    - TOX_ENV=py35     CONSUL_VERSION=0.7.5
 
-    # consul 0.5.2
-    - TOX_ENV=py27     CONSUL_VERSION=0.5.2
-    - TOX_ENV=py33     CONSUL_VERSION=0.5.2
-    - TOX_ENV=py34     CONSUL_VERSION=0.5.2
-    - TOX_ENV=py35     CONSUL_VERSION=0.5.2
+    # consul 0.8.5
+    - TOX_ENV=py27     CONSUL_VERSION=0.8.5
+    - TOX_ENV=py33     CONSUL_VERSION=0.8.5
+    - TOX_ENV=py34     CONSUL_VERSION=0.8.5
+    - TOX_ENV=py35     CONSUL_VERSION=0.8.5
 
-    # consul 0.6.4
-    - TOX_ENV=py27     CONSUL_VERSION=0.6.4
-    - TOX_ENV=py33     CONSUL_VERSION=0.6.4
-    - TOX_ENV=py34     CONSUL_VERSION=0.6.4
-    - TOX_ENV=py35     CONSUL_VERSION=0.6.4
+    # consul 0.9.0
+    - TOX_ENV=py27     CONSUL_VERSION=0.9.0
+    - TOX_ENV=py33     CONSUL_VERSION=0.9.0
+    - TOX_ENV=py34     CONSUL_VERSION=0.9.0
+    - TOX_ENV=py35     CONSUL_VERSION=0.9.0
 
     # coverage and style checks
-    - TOX_ENV=pep8     CONSUL_VERSION=0.4.1
-    - TOX_ENV=coverage CONSUL_VERSION=0.4.1
+    - TOX_ENV=pep8     CONSUL_VERSION=0.9.0
+    - TOX_ENV=coverage CONSUL_VERSION=0.9.0
 
 before_script:
   - wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-consul==0.4.0
+python-consul>=0.7.0,<0.8.0

--- a/src/ianitor/service.py
+++ b/src/ianitor/service.py
@@ -22,7 +22,7 @@ import subprocess
 import logging
 from requests import ConnectionError
 
-from consul import Check
+from consul import Check, ConsulException
 
 
 logger = logging.getLogger(__name__)
@@ -122,7 +122,9 @@ class Service(object):
         :return: None
         """
         with ignore_connection_errors("ttl_pass"):
-            if not self.session.agent.check.ttl_pass(self.check_id):
+            try:
+                self.session.agent.check.ttl_pass(self.check_id)
+            except ConsulException:
                 # register and ttl_pass again if it failed
                 logger.warning("service keep-alive failed, re-registering")
                 self.register()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -76,7 +76,7 @@ def test_remove_services():
         if description["ID"] != 'consul':
             agent.service.deregister(description["ID"])
 
-    # this is consul 0.4.1 behavior - consul is one of services
+    # this is consul behavior - consul is one of services
     services = agent.services()
     if 'consul' in services:
         services.pop('consul')
@@ -142,7 +142,6 @@ def _get_service_status(session, service_obj):
         # return none because check does not even exist
         return
 
-    # from pprint import pprint; pprint(checks)
     service_check = list(filter(
         lambda check: check["ServiceName"] == service_obj.service_name, checks
     )).pop()


### PR DESCRIPTION
* bump python-consul version to 0.7.0
* add addon for python3.5 (Travis does not provide it itself now)
* add Consul 0.8.5 to tests
* change `keep_alive` method; now `python-consul` raises an exception