### PR TITLE
enable ServiceAddress to be set

### DIFF
--- a/src/ianitor/args_parser.py
+++ b/src/ianitor/args_parser.py
@@ -142,6 +142,12 @@ def get_parser():
     )
 
     parser.add_argument(
+        "--address",
+        metavar="hostname", type=str,
+        help="set service address (if different than agent address)",
+    )
+
+    parser.add_argument(
         "--port",
         type=int,
         help="set service port",

--- a/src/ianitor/script.py
+++ b/src/ianitor/script.py
@@ -74,6 +74,7 @@ def main():
         service_name=args.service_name,
         service_id=args.id,
         tags=args.tags,
+        address=args.address,
         port=args.port
     )
 

--- a/src/ianitor/service.py
+++ b/src/ianitor/service.py
@@ -38,7 +38,7 @@ def ignore_connection_errors(action="unknown"):
 
 class Service(object):
     def __init__(self, command, session, ttl, service_name,
-                 service_id=None, tags=None, port=None):
+                 service_id=None, tags=None, port=None, address=None):
         self.command = command
         self.session = session
         self.process = None
@@ -47,6 +47,7 @@ class Service(object):
         self.service_name = service_name
         self.tags = tags or []
         self.port = port
+        self.address = address
         self.service_id = service_id or service_name
 
         self.check_id = "service:" + self.service_id
@@ -96,6 +97,7 @@ class Service(object):
                 service_id=self.service_id,
                 port=self.port,
                 tags=self.tags,
+                address=self.address,
                 # format the ttl into XXXs format
                 check=Check.ttl("%ss" % self.ttl)
             )


### PR DESCRIPTION
Supporting setting `--address=hostname` for `python-consul` to register a service address that [consul reports as `ServiceAddress`](https://python-consul.readthedocs.io/en/latest/#consul-agent):

```
$ ianitor --help  | grep address
               [--address hostname] [--port PORT] [-v]
  --consul-agent=hostname[:port]  set consul agent address
  --address=hostname              set service address (if different than agent
                                  address)
```

```
ianitor --address=10.20.1.15 --consul-agent 10.20.1.124 --tags recs --port 5656 --id recs-mk2 recs -- gunicorn --workers 1 --threads 1 --worker-class eventlet -b 0.0.0.0:5656 app:app
```

Listing the service:

```python
>>> pprint(c.catalog.service('recs'))
('1675',
 [{'Address': '10.20.1.124',
   'CreateIndex': 1675,
   'Datacenter': 'lab',
   'ID': '36c47aa1-8745-8867-6f4f-6d5b85b0b792',
   'ModifyIndex': 1675,
   'Node': 'maggie-kroesus-1',
   'NodeMeta': {'consul-network-segment': ''},
   'ServiceAddress': '10.20.1.15',
   'ServiceEnableTagOverride': False,
   'ServiceID': 'recs-mk2',
   'ServiceName': 'recs',
   'ServicePort': 5656,
   'ServiceTags': ['recs'],
   'TaggedAddresses': {'lan': '10.20.1.124', 'wan': '10.20.1.124'}}])
```